### PR TITLE
fix: Resolve critical errors on Admin and Police dashboards

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -93,6 +93,8 @@ model Case {
   lawyers         Lawyer[]
   medicalRecords  MedicalRecord[]
   deletedAt DateTime?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }
 
 model Region {

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -64,8 +64,7 @@ router.post('/login', async (req, res) => {
   }
 
   if (user && (await bcrypt.compare(password, user.password))) {
-    req.session.userId = user.id;
-    req.session.role = user.role.name;
+    req.session.user = user;
     console.log("Logged in role:", user.role.name);
     if (user.role.name === 'Police') {
       res.redirect('/dashboard/police');


### PR DESCRIPTION
This commit fixes two critical errors that were causing the Admin UI and the Police dashboard to crash.

The Admin Interface crash was caused by the `user` object not being passed to the `admin/jurisdiction` view. This has been resolved by storing the entire `user` object in the session upon login.

The Police Dashboard crash was caused by a missing `updatedAt` field in the `Case` model. This has been resolved by adding the `createdAt` and `updatedAt` fields to the `Case` model in the `prisma/schema.prisma` file.