### PR TITLE
fix: Resolve Forbidden error by correcting session data and middleware

### DIFF
--- a/__tests__/auth.test.js
+++ b/__tests__/auth.test.js
@@ -31,8 +31,12 @@ describe('Auth Middleware', () => {
   it('should return 403 if user does not have the correct role', () => {
     const req = {
       session: {
-        userId: 1,
-        role: 'Prosecutor',
+        user: {
+          id: 1,
+          role: {
+            name: 'Prosecutor',
+          },
+        },
       },
     };
     const res = {
@@ -51,8 +55,12 @@ describe('Auth Middleware', () => {
   it('should call next if user has the correct role', () => {
     const req = {
       session: {
-        userId: 1,
-        role: 'Police',
+        user: {
+          id: 1,
+          role: {
+            name: 'Police',
+          },
+        },
       },
     };
     const res = {

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -8,7 +8,7 @@ const isAuthenticated = (req, res, next) => {
 
 const checkRole = (roles) => {
   return (req, res, next) => {
-    if (req.session.userId && roles.includes(req.session.role)) {
+    if (req.session.user && roles.includes(req.session.user.role.name)) {
       next();
     } else {
       res.status(403).send('Forbidden');

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -68,7 +68,7 @@ router.post('/login', async (req, res, next) => {
     const userSessionData = {
       id: user.id,
       username: user.username,
-      role: user.role.name
+      role: user.role
     };
     console.log('[4/6] Created plain user object for session.');
 


### PR DESCRIPTION
This commit fixes a critical bug that was causing users to receive a "Forbidden" error when trying to access their dashboards.

The issue was twofold:
1. The `checkRole` middleware was checking `req.session.role` instead of the correct `req.session.user.role.name`.
2. The login route was storing only the role name in the session, instead of the entire role object.

This commit resolves the issue by:
- Updating the `checkRole` middleware to check the correct session property.
- Updating the login route to store the entire role object in the session.
- Updating the authentication tests to use the new session structure.