### PR TITLE
fix: Resolve PrismaClientValidationError in dashboard routes

### DIFF
--- a/routes/dashboard.js
+++ b/routes/dashboard.js
@@ -6,7 +6,7 @@ const { checkRole } = require('../middleware/auth');
 
 router.get('/police', checkRole(['Police']), async (req, res) => {
   const user = await prisma.user.findUnique({
-    where: { id: req.session.userId },
+    where: { id: req.session.user.id },
     include: { role: true },
   });
 
@@ -133,7 +133,7 @@ router.get('/police', checkRole(['Police']), async (req, res) => {
 
 router.get('/prosecutor', checkRole(['Prosecutor']), async (req, res) => {
   const user = await prisma.user.findUnique({
-    where: { id: req.session.userId },
+    where: { id: req.session.user.id },
     include: { role: true },
   });
 
@@ -197,7 +197,7 @@ router.get('/prosecutor', checkRole(['Prosecutor']), async (req, res) => {
 
 router.get('/court', checkRole(['Court']), async (req, res) => {
   const user = await prisma.user.findUnique({
-    where: { id: req.session.userId },
+    where: { id: req.session.user.id },
     include: { role: true },
   });
 


### PR DESCRIPTION
This commit fixes a `PrismaClientValidationError` that was occurring in the dashboard routes. The error was caused by the routes attempting to fetch the user from the database using `req.session.userId`, which was no longer being set in the session.

This commit resolves the issue by updating the dashboard routes to use `req.session.user.id` instead.