### PR TITLE
fix: Resolve ReferenceError in police dashboard

### DIFF
--- a/routes/dashboard.js
+++ b/routes/dashboard.js
@@ -49,7 +49,7 @@ router.get('/police', checkRole(['Police']), async (req, res) => {
   const newAssignments = 5; // dummy data
   const totalOpenCases = 15; // dummy data
   const warrantsPending = 2; // dummy data
-  const { sortBy, filterBy } = req.query;
+  const { sortBy = 'updated', filterBy = null } = req.query;
   let caseWhere = {
     actions: {
       some: {


### PR DESCRIPTION
This commit fixes a `ReferenceError` that was occurring in the police dashboard. The error was caused by the template attempting to access the `sortBy` and `filterBy` variables, which were only defined when passed as query parameters.

This commit resolves the issue by providing default values for the `sortBy` and `filterBy` variables in the police dashboard route handler.