### PR TITLE
Fix: Header error on unauthenticated pages

### DIFF
--- a/app.js
+++ b/app.js
@@ -42,6 +42,11 @@ try {
     saveUninitialized: true,
   }));
 
+  app.use((req, res, next) => {
+    res.locals.user = req.session.user;
+    next();
+  });
+
   const { getBreadcrumbs } = require('./utils/breadcrumbs');
   app.locals.getBreadcrumbs = getBreadcrumbs;
 

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -4,7 +4,9 @@
 <header class="bg-slate-800 px-6 py-4 flex justify-between items-center shadow-md">
     <h1 class="text-2xl font-bold">🚓 Police Dashboard</h1>
     <div class="flex items-center space-x-4">
-      <span class="text-sm text-slate-300">Logged in as <%= officer.username %></span>
+      <% if (user) { %>
+        <span class="text-sm text-slate-300">Logged in as <%= user.username %></span>
+      <% } %>
       <a href="/logout" class="bg-red-600 hover:bg-red-700 text-white px-3 py-1 rounded-md text-sm">Logout</a>
     </div>
   </header>


### PR DESCRIPTION
This commit fixes a bug where the header would throw an error on pages where you are not authenticated.

The `header.ejs` partial is updated to check if the `user` object exists before trying to access its properties.