### PR TITLE
Fix: Dashboard controller error

### DIFF
--- a/controllers/police/dashboard.controller.js
+++ b/controllers/police/dashboard.controller.js
@@ -9,7 +9,7 @@ exports.getDashboard = async (req, res) => {
     const overdueBookings = await prisma.booking.count({
       where: {
         status: 'Pending',
-        createdAt: {
+        bookingDate: {
           lt: twentyFourHoursAgo,
         },
       },


### PR DESCRIPTION
This commit fixes a bug in the dashboard controller where it was trying to query a non-existent field `createdAt` instead of `bookingDate`.

The `overdueBookings` query is updated to use the correct field.