### PR TITLE
Fix: Add missing routes for cases and people

### DIFF
--- a/routes/police.js
+++ b/routes/police.js
@@ -9,6 +9,14 @@ const { check, validationResult } = require('express-validator');
 // Dashboard
 router.get('/dashboard', isAuthenticated, getDashboardData);
 
+router.get('/cases', isAuthenticated, (req, res) => {
+    res.send('<h1>Police Cases</h1>');
+});
+
+router.get('/people', isAuthenticated, (req, res) => {
+    res.send('<h1>Police People</h1>');
+});
+
 // Person Selection/Creation
 router.get('/person/new', isAuthenticated, (req, res) => {
   res.render('police/person-step');


### PR DESCRIPTION
This commit adds the missing routes for `/police/cases` and `/police/people` to fix the 404 errors.