### PR TITLE
Fix: Add admin routes to app.js

### DIFF
--- a/app.js
+++ b/app.js
@@ -68,6 +68,7 @@ try {
   app.use('/dashboard', dashboardRouter);
   app.use('/police', require('./routes/police'));
   app.use('/api', require('./routes/api/search.routes'));
+  app.use('/admin', require('./routes/admin'));
   console.log('✅ Routes registered');
 } catch (err) {
   console.error('❌ Route registration failed:', err);


### PR DESCRIPTION
This commit fixes the 'Cannot GET /admin' error by adding the admin routes to the `app.js` file.