### PR TITLE
fix: Correctly populate user role in session

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -40,7 +40,7 @@ router.post('/login', async (req, res) => {
     req.session.user = {
       id: user.id,
       username: user.username,
-      role: user.role.name,
+      role: user.role,
     };
 
     console.log('Logged in:', req.session.user);


### PR DESCRIPTION
This commit fixes a bug where the SuperAdmin user was getting a "Forbidden" error when trying to access admin routes. The issue was that the user's role was being stored as a string in the session instead of an object.

The `ensureAdmin` middleware expects `req.session.user.role` to be an object with a `name` property, but it was receiving a string. This commit corrects the issue by storing the entire role object in the session.