### PR TITLE
fix: Configure EJS layouts

### DIFF
--- a/app.js
+++ b/app.js
@@ -22,6 +22,9 @@ const app = express();
 
 // 🧱 View engine setup
 try {
+  const expressLayouts = require('express-ejs-layouts');
+  app.use(expressLayouts);
+  app.set('layout', 'admin/layout'); // default layout
   app.set('views', path.join(__dirname, 'views'));
   app.set('view engine', 'ejs');
   console.log('✅ View engine configured');


### PR DESCRIPTION
This commit fixes a bug where the application was crashing with a "layout is not defined" error. This was because the `express-ejs-layouts` middleware was not configured.

This commit installs and configures `express-ejs-layouts` to correctly render EJS templates with layouts.