### PR TITLE
fix: Specify layout for admin routes only

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,7 +24,6 @@ const app = express();
 try {
   const expressLayouts = require('express-ejs-layouts');
   app.use(expressLayouts);
-  app.set('layout', 'admin/layout'); // default layout
   app.set('views', path.join(__dirname, 'views'));
   app.set('view engine', 'ejs');
   console.log('✅ View engine configured');

--- a/controllers/adminController.js
+++ b/controllers/adminController.js
@@ -2,17 +2,17 @@ const { PrismaClient } = require('@prisma/client');
 const prisma = new PrismaClient();
 
 exports.getDashboard = (req, res) => {
-  res.render('admin/dashboard');
+  res.render('admin/dashboard', { layout: 'admin/layout' });
 };
 
 // Regions
 exports.getRegions = async (req, res) => {
   const regions = await prisma.region.findMany();
-  res.render('admin/regions/index', { regions });
+  res.render('admin/regions/index', { regions, layout: 'admin/layout' });
 };
 
 exports.getNewRegion = (req, res) => {
-  res.render('admin/regions/new');
+  res.render('admin/regions/new', { layout: 'admin/layout' });
 };
 
 exports.createRegion = async (req, res) => {
@@ -25,12 +25,12 @@ exports.createRegion = async (req, res) => {
 exports.getDistricts = async (req, res) => {
   const districts = await prisma.district.findMany({ include: { region: true } });
   const regions = await prisma.region.findMany();
-  res.render('admin/districts/index', { districts, regions });
+  res.render('admin/districts/index', { districts, regions, layout: 'admin/layout' });
 };
 
 exports.getNewDistrict = async (req, res) => {
   const regions = await prisma.region.findMany();
-  res.render('admin/districts/new', { regions });
+  res.render('admin/districts/new', { regions, layout: 'admin/layout' });
 };
 
 exports.createDistrict = async (req, res) => {
@@ -43,12 +43,12 @@ exports.createDistrict = async (req, res) => {
 exports.getCities = async (req, res) => {
   const cities = await prisma.city.findMany({ include: { district: true } });
   const districts = await prisma.district.findMany();
-  res.render('admin/cities/index', { cities, districts });
+  res.render('admin/cities/index', { cities, districts, layout: 'admin/layout' });
 };
 
 exports.getNewCity = async (req, res) => {
   const districts = await prisma.district.findMany();
-  res.render('admin/cities/new', { districts });
+  res.render('admin/cities/new', { districts, layout: 'admin/layout' });
 };
 
 exports.createCity = async (req, res) => {
@@ -61,12 +61,12 @@ exports.createCity = async (req, res) => {
 exports.getPoliceStations = async (req, res) => {
   const policeStations = await prisma.policeStation.findMany();
   const cities = await prisma.city.findMany();
-  res.render('admin/police-stations/index', { policeStations, cities });
+  res.render('admin/police-stations/index', { policeStations, cities, layout: 'admin/layout' });
 };
 
 exports.getNewPoliceStation = async (req, res) => {
   const cities = await prisma.city.findMany();
-  res.render('admin/police-stations/new', { cities });
+  res.render('admin/police-stations/new', { cities, layout: 'admin/layout' });
 };
 
 exports.createPoliceStation = async (req, res) => {
@@ -79,12 +79,12 @@ exports.createPoliceStation = async (req, res) => {
 exports.getCourts = async (req, res) => {
   const courts = await prisma.court.findMany();
   const cities = await prisma.city.findMany();
-  res.render('admin/courts/index', { courts, cities });
+  res.render('admin/courts/index', { courts, cities, layout: 'admin/layout' });
 };
 
 exports.getNewCourt = async (req, res) => {
   const cities = await prisma.city.findMany();
-  res.render('admin/courts/new', { cities });
+  res.render('admin/courts/new', { cities, layout: 'admin/layout' });
 };
 
 exports.createCourt = async (req, res) => {


### PR DESCRIPTION
This commit fixes a bug where regular user login was broken after a previous fix for EJS layouts. The previous fix set a default layout for all views, which caused issues for non-admin pages.

This commit removes the default layout setting and instead specifies the 'admin/layout' for each admin route that renders a view. This ensures that only admin pages use the admin layout, and all other pages render correctly.