### PR TITLE
fix: Prevent default layout on login page

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,6 +24,8 @@ const app = express();
 try {
   const expressLayouts = require('express-ejs-layouts');
   app.use(expressLayouts);
+  app.set('layout extractScripts', true);
+  app.set('layout extractStyles', true);
   app.set('views', path.join(__dirname, 'views'));
   app.set('view engine', 'ejs');
   console.log('✅ View engine configured');

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -1,3 +1,4 @@
+<%_ locals.layout = false; %>
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
 <head>


### PR DESCRIPTION
This commit fixes a bug where the application was crashing with a "Failed to lookup view 'layout' in views directory" error. This was because the `express-ejs-layouts` middleware was still trying to render a default layout for the login page.

This commit explicitly tells EJS not to use a layout for the `login.ejs` view. It also updates `app.js` to set `extractScripts` and `extractStyles` to `true` for `express-ejs-layouts`, which is a best practice.