### PR TITLE
Fix: Use correct middleware in search route

### DIFF
--- a/routes/api/search.routes.js
+++ b/routes/api/search.routes.js
@@ -2,9 +2,9 @@ const express = require('express');
 const router = express.Router();
 const { PrismaClient } = require('@prisma/client');
 const prisma = new PrismaClient();
-const { isAuthenticated } = require('../../middleware/auth');
+const { ensureAuthenticated } = require('../../middleware/auth');
 
-router.get('/search', isAuthenticated, async (req, res) => {
+router.get('/search', ensureAuthenticated, async (req, res) => {
   const { q } = req.query;
 
   if (!q) {


### PR DESCRIPTION
This commit fixes a bug in the search API route that prevented the application from starting. The route was attempting to use an undefined middleware `isAuthenticated` instead of the correct `ensureAuthenticated`.

The following changes were made:
- In `routes/api/search.routes.js`, the `isAuthenticated` middleware has been replaced with `ensureAuthenticated`.