### PR TITLE
fix: Correct role handling in dashboard

### DIFF
--- a/routes/dashboard.js
+++ b/routes/dashboard.js
@@ -229,13 +229,14 @@ router.get('/court', checkRole(['Court']), async (req, res) => {
 
 router.get('/', (req, res) => {
   if (!req.session.user) {
-    return res.redirect('/auth/login');
+    return res.redirect('/login');
   }
 
-  const role = req.session.user.role.name;
+  const role = req.session.user.role; // Correctly access the role string
   switch (role) {
     case 'Police':
-      return res.redirect('/police/dashboard');
+      // The police dashboard is at /dashboard/police, not /police/dashboard
+      return res.redirect('/dashboard/police');
     case 'Prosecutor':
       return res.redirect('/prosecutor/dashboard');
     case 'Court':

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -9,7 +9,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link href="https://unpkg.com/heroicons@1.0.6/dist/outline.min.css" rel="stylesheet">
     <link href="/css/navbar.css" rel="stylesheet">
-    <% if (user.role.name === 'Police') { %>
+    <% if (user.role === 'Police') { %>
         <link href="/css/dashboard.css" rel="stylesheet">
     <% } else { %>
         <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
@@ -18,7 +18,7 @@
 <body style="padding-top: 64px;">
     <%- include('./partials/navbar', { user: user, page: page }) %>
 
-    <% if (user.role.name === 'Police') { %>
+    <% if (user.role === 'Police') { %>
         <div class="command-center">
             <div class="column left-column">
                 <div class="card alert-card">
@@ -111,12 +111,12 @@
             </div>
         </div>
         <script src="/js/live-search.js"></script>
-    <% } else if (user.role.name === 'Prosecutor') { %>
+    <% } else if (user.role === 'Prosecutor') { %>
         <div class="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
             <%- include('./partials/breadcrumbs', { breadcrumbs: breadcrumbs }) %>
             <div class="px-4 py-6 sm:px-0">
                 <h2 class="text-2xl font-bold text-gray-800 mb-4">Welcome, <%= user.username %>!</h2>
-                <p class="text-gray-600 mb-8">Your role is: <%= user.role.name %></p>
+                <p class="text-gray-600 mb-8">Your role is: <%= user.role %></p>
                 <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                     <div class="bg-white rounded-lg shadow-md p-6">
                         <h3 class="text-lg font-medium text-gray-800">Assigned Cases</h3>
@@ -188,12 +188,12 @@
                 </div>
             </div>
         </div>
-    <% } else if (user.role.name === 'Court') { %>
+    <% } else if (user.role === 'Court') { %>
         <div class="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
             <%- include('./partials/breadcrumbs', { breadcrumbs: breadcrumbs }) %>
             <div class="px-4 py-6 sm:px-0">
                 <h2 class="text-2xl font-bold text-gray-800 mb-4">Welcome, <%= user.username %>!</h2>
-                <p class="text-gray-600 mb-8">Your role is: <%= user.role.name %></p>
+                <p class="text-gray-600 mb-8">Your role is: <%= user.role %></p>
                 <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                     <div class="bg-white rounded-lg shadow-md p-6">
                         <h3 class="text-lg font-medium text-gray-800">Scheduled Hearings</h3>


### PR DESCRIPTION
After implementing the new authentication system, the dashboard was rendering a blank page for logged-in users. This was caused by an inconsistency in how the user's role was accessed from the session object.

The login controller stored the role as a simple string (`req.session.user.role`), while the dashboard router and view were expecting an object with a name property (`req.session.user.role.name`).

This commit corrects this inconsistency by updating all references in `routes/dashboard.js` and `views/dashboard.ejs` to use the correct `req.session.user.role`, ensuring that users are properly redirected and that the dashboard content renders as expected.