### PR TITLE
fix: Pass sortBy and filterBy to dashboard view

### DIFF
--- a/routes/dashboard.js
+++ b/routes/dashboard.js
@@ -123,7 +123,9 @@ router.get('/police', checkRole(['Police']), async (req, res) => {
     totalOpenCases,
     warrantsPending,
     cases,
-    upcomingEvents
+    upcomingEvents,
+    sortBy,
+    filterBy
   });
 });
 


### PR DESCRIPTION
The police dashboard view was throwing a `ReferenceError` because the `sortBy` variable, used in the sorting dropdown, was not being passed to the EJS render function.

This commit resolves the error by adding the `sortBy` and `filterBy` variables to the object passed to `res.render` within the `GET /dashboard/police` route in `routes/dashboard.js`.