### PR TITLE
feat: Restore admin panel functionality

### DIFF
--- a/app.js
+++ b/app.js
@@ -92,6 +92,7 @@ try {
   app.use('/warrants', require('./routes/warrants'));
   app.use('/api/search', require('./routes/api/search.routes'));
   app.use('/api/bookings', require('./routes/api/bookings'));
+  app.use('/api/admin', require('./routes/api/admin'));
   app.use('/admin', require('./routes/admin'));
 
   console.log('✅ Routes registered');

--- a/controllers/adminController.js
+++ b/controllers/adminController.js
@@ -100,3 +100,110 @@ exports.createCourt = async (req, res) => {
   await prisma.court.create({ data: { name, cityId: parseInt(cityId) } });
   res.redirect('/admin/courts');
 };
+
+// --- API Functions ---
+
+// List Regions
+exports.listRegions = async (req, res, next) => {
+  try {
+    const regions = await prisma.region.findMany();
+    res.json(regions);
+  } catch (e) {
+    next(e);
+  }
+};
+
+// Create Region (API)
+exports.createRegionApi = async (req, res, next) => {
+  try {
+    const { name } = req.body;
+    const newRegion = await prisma.region.create({ data: { name } });
+    res.status(201).json(newRegion);
+  } catch (e) {
+    next(e);
+  }
+};
+
+// List Districts
+exports.listDistricts = async (req, res, next) => {
+  try {
+    const districts = await prisma.district.findMany();
+    res.json(districts);
+  } catch (e) {
+    next(e);
+  }
+};
+
+// Create District (API)
+exports.createDistrictApi = async (req, res, next) => {
+  try {
+    const { name, regionId } = req.body;
+    const newDistrict = await prisma.district.create({ data: { name, regionId: parseInt(regionId) } });
+    res.status(201).json(newDistrict);
+  } catch (e) {
+    next(e);
+  }
+};
+
+// List Cities
+exports.listCities = async (req, res, next) => {
+  try {
+    const cities = await prisma.city.findMany();
+    res.json(cities);
+  } catch (e) {
+    next(e);
+  }
+};
+
+// Create City (API)
+exports.createCityApi = async (req, res, next) => {
+  try {
+    const { name, districtId } = req.body;
+    const newCity = await prisma.city.create({ data: { name, districtId: parseInt(districtId) } });
+    res.status(201).json(newCity);
+  } catch (e) {
+    next(e);
+  }
+};
+
+// List Police Stations
+exports.listStations = async (req, res, next) => {
+  try {
+    const stations = await prisma.policeStation.findMany();
+    res.json(stations);
+  } catch (e) {
+    next(e);
+  }
+};
+
+// Create Police Station (API)
+exports.createStationApi = async (req, res, next) => {
+  try {
+    const { name, cityId } = req.body;
+    const newStation = await prisma.policeStation.create({ data: { name, cityId: parseInt(cityId) } });
+    res.status(201).json(newStation);
+  } catch (e) {
+    next(e);
+  }
+};
+
+// List Courts
+exports.listCourts = async (req, res, next) => {
+  try {
+    const courts = await prisma.court.findMany();
+    res.json(courts);
+  } catch (e) {
+    next(e);
+  }
+};
+
+// Create Court (API)
+exports.createCourtApi = async (req, res, next) => {
+  try {
+    const { name, cityId } = req.body;
+    const newCourt = await prisma.court.create({ data: { name, cityId: parseInt(cityId) } });
+    res.status(201).json(newCourt);
+  } catch (e) {
+    next(e);
+  }
+};

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -114,16 +114,19 @@ model District {
 }
 
 model City {
-  id         Int      @id @default(autoincrement())
-  name       String   @unique
-  district   District @relation(fields: [districtId], references: [id])
+  id         Int           @id @default(autoincrement())
+  name       String        @unique
+  district   District      @relation(fields: [districtId], references: [id])
   districtId Int
+  stations   PoliceStation[]
+  courts     Court[]
 }
 
 model PoliceStation {
   id       Int       @id @default(autoincrement())
   name     String    @unique
   cityId   Int
+  city     City      @relation(fields: [cityId], references: [id])
   bookings Booking[]
 }
 
@@ -131,6 +134,7 @@ model Court {
   id       Int       @id @default(autoincrement())
   name     String    @unique
   cityId   Int
+  city     City      @relation(fields: [cityId], references: [id])
   hearings Hearing[]
 }
 

--- a/routes/api/admin.js
+++ b/routes/api/admin.js
@@ -1,0 +1,24 @@
+const router = require('express').Router();
+const adminCtrl = require('../../controllers/adminController');
+
+// Regions
+router.get('/regions',    adminCtrl.listRegions);
+router.post('/regions',   adminCtrl.createRegionApi);
+
+// Districts
+router.get('/districts',  adminCtrl.listDistricts);
+router.post('/districts', adminCtrl.createDistrictApi);
+
+// Cities
+router.get('/cities',     adminCtrl.listCities);
+router.post('/cities',    adminCtrl.createCityApi);
+
+// Police Stations
+router.get('/stations',   adminCtrl.listStations);
+router.post('/stations',  adminCtrl.createStationApi);
+
+// Courts
+router.get('/courts',     adminCtrl.listCourts);
+router.post('/courts',    adminCtrl.createCourtApi);
+
+module.exports = router;


### PR DESCRIPTION
This commit fixes the admin panel by addressing several issues across the backend and database schema.

- Corrected the Prisma schema by adding the missing relations between City, PoliceStation, and Court models. This resolves the primary issue causing admin pages to appear blank.
- Created new JSON API endpoints under `/api/admin/` for regions, districts, cities, stations, and courts, as per the requirements.
- Added corresponding API handler functions in the admin controller for both listing and creating resources, which return JSON instead of redirecting.
- Registered the new API routes in `app.js`.
- Created a `.env` file to support the use of the provided database credentials for running the application.