### PR TITLE
fix: Implement find-or-create logic for person on case creation

### DIFF
--- a/controllers/policeController.js
+++ b/controllers/policeController.js
@@ -231,13 +231,21 @@ exports.postNewCaseConfirm = async (req, res, next) => {
 
         const caseNumber = generateCaseNumber(region.name, city.name);
 
-        const person = await prisma.person.create({
-        data: {
-            name,
-            email,
-            dob: new Date(dob),
-        },
-    });
+        // --- Find or Create Person Logic ---
+        let person = await prisma.person.findUnique({
+            where: { email: email },
+        });
+
+        if (!person) {
+            person = await prisma.person.create({
+                data: {
+                    name,
+                    email,
+                    dob: new Date(dob),
+                },
+            });
+        }
+        // --- End Find or Create Person Logic ---
     const booking = await prisma.booking.create({
         data: {
             personId: person.id,


### PR DESCRIPTION
This commit fixes a critical logic error in the case creation process. The previous implementation always attempted to create a new person, which caused a `Unique constraint failed` error if a person with the same email already existed in the database.

The `postNewCaseConfirm` function in `controllers/policeController.js` has been updated to:
1. First, search for an existing person by their email address.
2. If a person is found, use that existing person's ID.
3. If no person is found, create a new person record.

This ensures data integrity and prevents the application from crashing when creating cases for individuals who are already in the system.