### PR TITLE
fix: Correct Prisma update syntax for booking-case relation

### DIFF
--- a/controllers/policeController.js
+++ b/controllers/policeController.js
@@ -264,7 +264,11 @@ exports.postNewCaseConfirm = async (req, res, next) => {
     });
     await prisma.booking.update({
         where: { id: booking.id },
-        data: { caseId: createdCase.id },
+        data: {
+            case: {
+                connect: { id: createdCase.id },
+            },
+        },
     });
     delete req.session.caseData;
     res.redirect('/police/management');


### PR DESCRIPTION
This commit fixes the final bug in the case creation process. The application was crashing with a `PrismaClientValidationError` because it was using an incorrect syntax to associate a case with a booking.

The `prisma.booking.update` call in `controllers/policeController.js` was attempting to set a `caseId` field directly. This has been corrected to use the proper Prisma syntax for updating relations, which is to use the relation field (`case`) with a `connect` object.

This resolves the `Unknown argument 'caseId'` error and completes the case creation workflow.