### PR TITLE
feat: Implement case detail cards with animated slide-over

### DIFF
--- a/public/css/cards.css
+++ b/public/css/cards.css
@@ -1,0 +1,54 @@
+.cards-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px,1fr));
+  gap: 1rem;
+}
+.card {
+  background: #fff;
+  border-radius: 8px;
+  padding: 1rem;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.1);
+  transition: transform .2s, box-shadow .2s;
+  cursor: pointer;
+  outline: none;
+}
+.card:focus,
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+}
+.badge {
+  position: absolute; top: .75rem; right: .75rem;
+  background: #007bff; color: #fff; border-radius: 12px;
+  padding: .25rem .5rem;
+}
+.manage-btn {
+  margin-top: .5rem;
+  border: 1px solid #007bff; color: #007bff;
+  background: transparent; border-radius: 4px;
+}
+
+.slide-over {
+  position: fixed; inset: 0; display: flex; pointer-events: none;
+}
+.backdrop {
+  position: absolute; inset: 0;
+  background: rgba(0,0,0,0.4); opacity: 0;
+  transition: opacity .3s;
+}
+.panel {
+  margin-left: auto; width: 400px; background: #fff;
+  height: 100%; transform: translateX(100%);
+  transition: transform .3s;
+}
+.slide-over[x-show="open"] .backdrop {
+  opacity: 1; pointer-events: auto;
+}
+.slide-over[x-show="open"] .panel {
+  transform: translateX(0); pointer-events: auto;
+}
+.close-btn {
+  position: absolute; top: .5rem; right: .5rem;
+  background: none; border: none; font-size: 1.5rem;
+  cursor: pointer;
+}

--- a/public/js/cards.js
+++ b/public/js/cards.js
@@ -1,0 +1,97 @@
+function openSlideOver(mod) {
+  const so = document.getElementById('slideOver');
+  so.__x.$data.module = mod;
+  so.__x.$data.open = true;
+
+  fetch(`/police/cases/${CASE_ID}/${mod}`)
+    .then(res => res.json())
+    .then(data => {
+      const listHtml = renderList(mod, data);
+      const formHtml = renderForm(mod);
+      document.getElementById('moduleContent').innerHTML = listHtml + formHtml;
+    });
+}
+
+function closeSlideOver() {
+  document.getElementById('slideOver').__x.$data.open = false;
+}
+
+function renderList(mod, data) {
+  let itemsHtml = '<p>No items yet.</p>';
+  if (data && data.length > 0) {
+    itemsHtml = '<ul>' + data.map(item => `<li>${getListItem(mod, item)}</li>`).join('') + '</ul>';
+  }
+  return `<h2>${window.labels[mod]}</h2>${itemsHtml}`;
+}
+
+function getListItem(mod, item) {
+  switch (mod) {
+    case 'evidence':
+      return `${item.evidenceType}: ${item.description}`;
+    case 'investigations':
+      return `${item.investigatorName}: ${item.details}`;
+    case 'victims':
+      return `${item.name} — ${item.statement || 'No statement'}`;
+    case 'witnesses':
+      return `${item.name} — ${item.statement || 'No statement'}`;
+    case 'hearings':
+      return `${new Date(item.hearingDate).toLocaleString()} — ${item.verdict || 'No verdict'}`;
+    case 'warrants':
+      return `${item.status}: ${item.details}`;
+    default:
+      return JSON.stringify(item);
+  }
+}
+
+function renderForm(mod) {
+  const formContent = getFormFields(mod);
+  return `
+    <hr class="my-4">
+    <h3>Add New ${window.labels[mod]}</h3>
+    <form action="/police/cases/${CASE_ID}/${mod}" method="POST">
+      ${formContent}
+      <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded mt-2">Add</button>
+    </form>
+  `;
+}
+
+function getFormFields(mod) {
+  switch (mod) {
+    case 'evidence':
+      return `
+        <input type="text" name="evidenceType" placeholder="Evidence Type" class="border p-1 w-full">
+        <textarea name="description" placeholder="Description" class="border p-1 w-full mt-2"></textarea>
+      `;
+    case 'investigations':
+      return `
+        <input type="text" name="investigatorName" placeholder="Investigator Name" class="border p-1 w-full">
+        <input type="text" name="investigatorBadgeNumber" placeholder="Badge Number" class="border p-1 w-full mt-2">
+        <input type="text" name="investigatorRank" placeholder="Rank" class="border p-1 w-full mt-2">
+        <textarea name="details" placeholder="Details" class="border p-1 w-full mt-2"></textarea>
+      `;
+    case 'victims':
+      return `
+        <input type="text" name="name" placeholder="Victim Name" class="border p-1 w-full">
+        <textarea name="statement" placeholder="Statement" class="border p-1 w-full mt-2"></textarea>
+      `;
+    case 'witnesses':
+      return `
+        <input type="text" name="name" placeholder="Witness Name" class="border p-1 w-full">
+        <textarea name="statement" placeholder="Statement" class="border p-1 w-full mt-2"></textarea>
+      `;
+    case 'hearings':
+      return `
+        <input type="datetime-local" name="hearingDate" class="border p-1 w-full">
+        <input type="text" name="verdict" placeholder="Verdict" class="border p-1 w-full mt-2">
+        <input type="text" name="courtId" placeholder="Court ID" class="border p-1 w-full mt-2">
+      `;
+    case 'warrants':
+      return `
+        <input type="text" name="status" placeholder="Status" class="border p-1 w-full">
+        <textarea name="details" placeholder="Details" class="border p-1 w-full mt-2"></textarea>
+        <input type="datetime-local" name="expiresAt" class="border p-1 w-full mt-2">
+      `;
+    default:
+      return '';
+  }
+}

--- a/routes/police.js
+++ b/routes/police.js
@@ -42,4 +42,23 @@ router.post('/bookings/:id/edit', ensureAuthenticated, policeController.postEdit
 // Search
 router.get('/search', ensureAuthenticated, policeController.search);
 
+// Case Detail View
+router.get('/cases/:caseId/view', ensureAuthenticated, policeController.getCaseDetail);
+
+// Dynamic module routes
+const caseModules = ['evidence', 'investigations', 'victims', 'witnesses', 'hearings', 'warrants'];
+caseModules.forEach(mod => {
+    const controllerName = mod.charAt(0).toUpperCase() + mod.slice(1);
+    router.get(
+        `/cases/:caseId/${mod}`,
+        ensureAuthenticated,
+        policeController[`get${controllerName}List`]
+    );
+    router.post(
+        `/cases/:caseId/${mod}`,
+        ensureAuthenticated,
+        policeController[`post${controllerName}`]
+    );
+});
+
 module.exports = router;

--- a/views/partials/evidence-form.ejs
+++ b/views/partials/evidence-form.ejs
@@ -1,4 +1,4 @@
-<form action="/cases/<%= booking.case.id %>/evidence" method="POST">
+<form action="/police/cases/<%= case.id %>/evidence" method="POST">
   <input type="text" name="evidenceType" placeholder="Evidence Type">
   <textarea name="description" placeholder="Description"></textarea>
   <button type="submit">Add Evidence</button>

--- a/views/partials/evidence-list.ejs
+++ b/views/partials/evidence-list.ejs
@@ -1,7 +1,7 @@
 <h2>Evidence</h2>
-<% if (booking.evidence && booking.evidence.length > 0) { %>
+<% if (case.evidence && case.evidence.length > 0) { %>
   <ul>
-    <% booking.evidence.forEach(e => { %>
+    <% case.evidence.forEach(e => { %>
       <li><%= e.evidenceType %>: <%= e.description %></li>
     <% }) %>
   </ul>

--- a/views/partials/head.ejs
+++ b/views/partials/head.ejs
@@ -2,4 +2,5 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Justice 3.0</title>
 <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+<link rel="stylesheet" href="/css/cards.css">
 <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>

--- a/views/partials/hearing-form.ejs
+++ b/views/partials/hearing-form.ejs
@@ -1,4 +1,4 @@
-<form action="/cases/<%= booking.case.id %>/hearings" method="POST">
+<form action="/police/cases/<%= case.id %>/hearings" method="POST">
   <input type="datetime-local" name="hearingDate">
   <input type="text" name="verdict" placeholder="Verdict">
   <select name="courtId">

--- a/views/partials/hearings-list.ejs
+++ b/views/partials/hearings-list.ejs
@@ -1,7 +1,7 @@
 <h2>Hearings</h2>
-<% if (booking.case.hearings && booking.case.hearings.length > 0) { %>
+<% if (case.hearings && case.hearings.length > 0) { %>
   <ul>
-    <% booking.case.hearings.forEach(h => { %>
+    <% case.hearings.forEach(h => { %>
       <li><%= h.hearingDate.toLocaleString() %> — <%= h.verdict || 'No verdict' %></li>
     <% }) %>
   </ul>

--- a/views/partials/investigations-form.ejs
+++ b/views/partials/investigations-form.ejs
@@ -1,0 +1,7 @@
+<form action="/police/cases/<%= case.id %>/investigations" method="POST">
+  <input type="text" name="investigatorName" placeholder="Investigator Name">
+  <input type="text" name="investigatorBadgeNumber" placeholder="Badge Number">
+  <input type="text" name="investigatorRank" placeholder="Rank">
+  <textarea name="details" placeholder="Details"></textarea>
+  <button type="submit">Add Investigation</button>
+</form>

--- a/views/partials/investigations-list.ejs
+++ b/views/partials/investigations-list.ejs
@@ -1,0 +1,10 @@
+<h2>Investigations</h2>
+<% if (case.investigations && case.investigations.length > 0) { %>
+  <ul>
+    <% case.investigations.forEach(i => { %>
+      <li><%= i.investigatorName %>: <%= i.details %></li>
+    <% }) %>
+  </ul>
+<% } else { %>
+  <p>No investigations added yet.</p>
+<% } %>

--- a/views/partials/victim-form.ejs
+++ b/views/partials/victim-form.ejs
@@ -1,4 +1,4 @@
-<form action="/cases/<%= booking.case.id %>/victims" method="POST">
+<form action="/police/cases/<%= case.id %>/victims" method="POST">
   <input type="text" name="name" placeholder="Victim Name">
   <textarea name="statement" placeholder="Statement"></textarea>
   <button type="submit">Add Victim</button>

--- a/views/partials/victims-list.ejs
+++ b/views/partials/victims-list.ejs
@@ -1,7 +1,7 @@
 <h2>Victims</h2>
-<% if (booking.victims && booking.victims.length > 0) { %>
+<% if (case.victims && case.victims.length > 0) { %>
   <ul>
-    <% booking.victims.forEach(v => { %>
+    <% case.victims.forEach(v => { %>
       <li><%= v.name %> — <%= v.statement || 'No statement' %></li>
     <% }) %>
   </ul>

--- a/views/partials/warrants-form.ejs
+++ b/views/partials/warrants-form.ejs
@@ -1,0 +1,6 @@
+<form action="/police/cases/<%= case.id %>/warrants" method="POST">
+  <input type="text" name="status" placeholder="Status">
+  <textarea name="details" placeholder="Details"></textarea>
+  <input type="datetime-local" name="expiresAt">
+  <button type="submit">Add Warrant</button>
+</form>

--- a/views/partials/warrants-list.ejs
+++ b/views/partials/warrants-list.ejs
@@ -1,0 +1,10 @@
+<h2>Warrants</h2>
+<% if (case.warrants && case.warrants.length > 0) { %>
+  <ul>
+    <% case.warrants.forEach(w => { %>
+      <li><%= w.status %>: <%= w.details %></li>
+    <% }) %>
+  </ul>
+<% } else { %>
+  <p>No warrants added yet.</p>
+<% } %>

--- a/views/partials/witness-form.ejs
+++ b/views/partials/witness-form.ejs
@@ -1,4 +1,4 @@
-<form action="/cases/<%= booking.case.id %>/witnesses" method="POST">
+<form action="/police/cases/<%= case.id %>/witnesses" method="POST">
   <input type="text" name="name" placeholder="Witness Name">
   <textarea name="statement" placeholder="Statement"></textarea>
   <button type="submit">Add Witness</button>

--- a/views/partials/witnesses-list.ejs
+++ b/views/partials/witnesses-list.ejs
@@ -1,7 +1,7 @@
 <h2>Witnesses</h2>
-<% if (booking.case.witnesses && booking.case.witnesses.length > 0) { %>
+<% if (case.witnesses && case.witnesses.length > 0) { %>
   <ul>
-    <% booking.case.witnesses.forEach(w => { %>
+    <% case.witnesses.forEach(w => { %>
       <li><%= w.name %> — <%= w.statement || 'No statement' %></li>
     <% }) %>
   </ul>

--- a/views/police/case-detail.ejs
+++ b/views/police/case-detail.ejs
@@ -1,0 +1,45 @@
+<%- include('../partials/header') %>
+
+<script>const CASE_ID = <%= case.id %>;</script>
+<script>window.labels = <%- JSON.stringify(labels) %>;</script>
+<script>window.icons  = <%- JSON.stringify(icons) %>;</script>
+
+<section class="cards-container">
+  <div class="cards-grid">
+    <% Object.keys(counts).forEach(mod => { %>
+      <div
+        class="card"
+        tabindex="0"
+        x-data
+        @click="openSlideOver('<%= mod %>')"
+        @keydown.enter="openSlideOver('<%= mod %>')"
+      >
+        <i :class="`fas fa-${icons[mod]} fa-2x`"></i>
+        <h3><%= labels[mod] %></h3>
+        <span class="badge"><%= counts[mod] %></span>
+        <button class="manage-btn">Manage</button>
+      </div>
+    <% }) %>
+  </div>
+</section>
+
+<div
+  id="slideOver"
+  class="slide-over"
+  x-data="{ open: false, module: '' }"
+  x-show="open"
+  @keydown.window.escape="closeSlideOver()"
+  x-cloak
+>
+  <div class="backdrop" @click="closeSlideOver()"></div>
+  <div class="panel"
+       :class="{ 'enter': open, 'leave': !open }"
+  >
+    <button class="close-btn" @click="closeSlideOver()">×</button>
+    <h2 x-text="labels[module]"></h2>
+    <div id="moduleContent"></div>
+  </div>
+</div>
+
+<script src="/js/cards.js"></script>
+<%- include('../partials/footer') %>

--- a/views/police/management.ejs
+++ b/views/police/management.ejs
@@ -50,7 +50,7 @@
                       <%= new Date(c.booking.bookingDate).toLocaleDateString() %>
                     </td>
                     <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                      <a href="/police/bookings/<%= c.bookingId %>" class="text-indigo-600 hover:text-indigo-900">View</a>
+                      <a href="/police/cases/<%= c.id %>/view" class="text-indigo-600 hover:text-indigo-900">View Details</a>
                     </td>
                   </tr>
                 <% }) %>


### PR DESCRIPTION
This commit introduces a new dashboard-style case detail page.

Features:
- A grid of cards representing different modules (evidence, victims, etc.).
- Each card displays a label, icon, and a count of items in that module.
- Cards are clickable and keyboard-accessible, opening a slide-over panel.
- The slide-over panel animates in and out smoothly.
- The panel content (list of items and a form) is loaded dynamically via AJAX.
- The feature is built using existing partials and endpoints, with new controller logic to support the dashboard view and AJAX calls.

Implementation Details:
- Added `getCaseDetail` to `policeController.js` to fetch data for the card grid.
- Added `get<Module>List` and `post<Module>` functions to the controller to handle AJAX requests and form submissions for each module.
- Created a new view `views/police/case-detail.ejs` for the card grid and slide-over panel.
- Added CSS for the card layout and animations in `public/css/cards.css`.
- Added JavaScript in `public/js/cards.js` to handle the slide-over interactivity and dynamic content loading.
- Updated and created EJS partials for each module to ensure they can be rendered from the new JSON endpoints.