### PR TITLE
fix: Resolve EJS syntax error in case detail view

### DIFF
--- a/controllers/policeController.js
+++ b/controllers/policeController.js
@@ -627,7 +627,7 @@ exports.getCaseDetail = async (req, res, next) => {
         }, {});
 
         res.render('police/case-detail', {
-            case: caseData,
+            caseData: caseData,
             counts,
             labels,
             icons,

--- a/views/police/case-detail.ejs
+++ b/views/police/case-detail.ejs
@@ -1,6 +1,6 @@
 <%- include('../partials/header') %>
 
-<script>const CASE_ID = <%= case.id %>;</script>
+<script>const CASE_ID = <%= caseData.id %>;</script>
 <script>window.labels = <%- JSON.stringify(labels) %>;</script>
 <script>window.icons  = <%- JSON.stringify(icons) %>;</script>
 


### PR DESCRIPTION
This commit fixes a critical syntax error in the `case-detail.ejs` view that was preventing the page from rendering. The error `SyntaxError: Unexpected token 'case'` was caused by using the reserved JavaScript keyword 'case' as a variable name.

The fix involves:
1.  Renaming the `case` key to `caseData` in the object passed to `res.render` in the `getCaseDetail` function of `controllers/policeController.js`.
2.  Updating the `case-detail.ejs` template to use `caseData` instead of `case`.

This resolves the rendering error and should allow the new case detail page to load correctly.