### PR TITLE
feat: Revamp police dashboard and separate case/person management

### DIFF
--- a/routes/police.js
+++ b/routes/police.js
@@ -8,8 +8,8 @@ router.get('/dashboard', ensureAuthenticated, policeController.getDashboardData)
 
 // Management
 router.get('/management', ensureAuthenticated, policeController.getManagementData);
-router.get('/cases', ensureAuthenticated, (req, res) => res.redirect('/police/management'));
-router.get('/people', ensureAuthenticated, (req, res) => res.redirect('/police/management'));
+router.get('/cases', ensureAuthenticated, policeController.getCaseList);
+router.get('/people', ensureAuthenticated, policeController.getPersonList);
 
 const checkStep = (step) => (req, res, next) => {
     if (req.session.caseData && req.session.caseData.step >= step) {

--- a/views/police/case-list.ejs
+++ b/views/police/case-list.ejs
@@ -1,0 +1,47 @@
+<%- include('../partials/header') %>
+
+<div class="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
+    <h2 class="text-2xl font-bold text-gray-800 mb-8">Case List</h2>
+    <div class="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
+        <table class="min-w-full divide-y divide-gray-200">
+            <thead class="bg-gray-50">
+                <tr>
+                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Case Number
+                    </th>
+                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Status
+                    </th>
+                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Booking Date
+                    </th>
+                    <th scope="col" class="relative px-6 py-3">
+                        <span class="sr-only">View</span>
+                    </th>
+                </tr>
+            </thead>
+            <tbody class="bg-white divide-y divide-gray-200">
+                <% cases.forEach(c => { %>
+                <tr>
+                    <td class="px-6 py-4 whitespace-nowrap">
+                        <div class="text-sm text-gray-900"><%= c.caseNumber %></div>
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap">
+                        <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full <%= c.status === 'Open' ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800' %>">
+                        <%= c.status %>
+                        </span>
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        <%= new Date(c.booking.bookingDate).toLocaleDateString() %>
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                        <a href="/police/cases/<%= c.id %>/view" class="text-indigo-600 hover:text-indigo-900 view-link">View Details</a>
+                    </td>
+                </tr>
+                <% }) %>
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<%- include('../partials/footer') %>

--- a/views/police/person-list.ejs
+++ b/views/police/person-list.ejs
@@ -1,0 +1,39 @@
+<%- include('../partials/header') %>
+
+<div class="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
+    <h2 class="text-2xl font-bold text-gray-800 mb-8">Person List</h2>
+    <div class="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
+        <table class="min-w-full divide-y divide-gray-200">
+            <thead class="bg-gray-50">
+                <tr>
+                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Name
+                    </th>
+                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Email
+                    </th>
+                    <th scope="col" class="relative px-6 py-3">
+                        <span class="sr-only">View</span>
+                    </th>
+                </tr>
+            </thead>
+            <tbody class="bg-white divide-y divide-gray-200">
+                <% people.forEach(p => { %>
+                <tr>
+                    <td class="px-6 py-4 whitespace-nowrap">
+                        <div class="text-sm text-gray-900"><%= p.name %></div>
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap">
+                        <div class="text-sm text-gray-900"><%= p.email %></div>
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                        <a href="/police/people/<%= p.id %>" class="text-indigo-600 hover:text-indigo-900 view-link">View</a>
+                    </td>
+                </tr>
+                <% }) %>
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<%- include('../partials/footer') %>

--- a/views/police/police_dashboard.ejs
+++ b/views/police/police_dashboard.ejs
@@ -1,21 +1,22 @@
-<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<%- include('../partials/header') %>
+
 <div class="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
-  <%- include('../partials/breadcrumbs', { current: 'Dashboard' }) %>
+  <h1 class="text-2xl font-bold text-gray-800 mb-8">Dashboard</h1>
 
-  <div class="px-4 py-6 sm:px-0">
-    <h2 class="text-2xl font-bold text-gray-800 mb-4">Welcome, <%= user.username %>!</h2>
-    <p class="text-gray-600 mb-8">Your role is: <%= user.role.name %></p>
-
-    <%- include('../partials/search-form') %>
-
-    <%- include('../partials/card-summary', { stats }) %>
-
-    <div class="mt-8">
-      <a href="/police/people/new" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">Register New Person</a>
+  <section class="cards-grid">
+    <div class="card">
+      <i class="fas fa-folder-open fa-2x"></i>
+      <h3 class="text-xl font-bold mt-2">Manage Cases</h3>
+      <p class="text-gray-600 mt-2"><%= caseCount %> active cases</p>
+      <a class="inline-block mt-4 bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" href="/police/cases">Go to Cases</a>
     </div>
-
-    <%- include('../partials/card-expiring', { expiringCustody }) %>
-    <%- include('../partials/card-bookings', { userBookings }) %>
-    <%- include('../partials/chart-booking-status', { bookingStatusData }) %>
-  </div>
+    <div class="card">
+      <i class="fas fa-user-friends fa-2x"></i>
+      <h3 class="text-xl font-bold mt-2">Manage People</h3>
+      <p class="text-gray-600 mt-2"><%= personCount %> individuals</p>
+      <a class="inline-block mt-4 bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" href="/police/people">Go to People</a>
+    </div>
+  </section>
 </div>
+
+<%- include('../partials/footer') %>


### PR DESCRIPTION
This commit implements a major revamp of the police dashboard to address several UI and navigation issues.

The key changes are:
- The main police dashboard (`/police/dashboard`) has been redesigned with a clean, card-based layout. It now provides clear entry points to "Manage Cases" and "Manage People".
- The previously combined "Case & Person Management" page has been removed.
- New, separate list pages have been created for cases (`/police/cases`) and people (`/police/people`).
- The `getDashboardData` controller has been updated to provide the necessary counts for the new dashboard cards.
- New controller functions (`getCaseList`, `getPersonList`) and routes have been added to support the new list pages.
- The "View Details" links in the case list now correctly point to the `/police/cases/:caseId/view` route, making the case detail feature accessible.