### PR TITLE
fix: Resolve EJS syntax error in all partials

### DIFF
--- a/views/partials/evidence-form.ejs
+++ b/views/partials/evidence-form.ejs
@@ -1,4 +1,4 @@
-<form action="/police/cases/<%= case.id %>/evidence" method="POST">
+<form action="/police/cases/<%= caseData.id %>/evidence" method="POST">
   <input type="text" name="evidenceType" placeholder="Evidence Type">
   <textarea name="description" placeholder="Description"></textarea>
   <button type="submit">Add Evidence</button>

--- a/views/partials/evidence-list.ejs
+++ b/views/partials/evidence-list.ejs
@@ -1,7 +1,7 @@
 <h2>Evidence</h2>
-<% if (case.evidence && case.evidence.length > 0) { %>
+<% if (caseData.evidence && caseData.evidence.length > 0) { %>
   <ul>
-    <% case.evidence.forEach(e => { %>
+    <% caseData.evidence.forEach(e => { %>
       <li><%= e.evidenceType %>: <%= e.description %></li>
     <% }) %>
   </ul>

--- a/views/partials/hearing-form.ejs
+++ b/views/partials/hearing-form.ejs
@@ -1,4 +1,4 @@
-<form action="/police/cases/<%= case.id %>/hearings" method="POST">
+<form action="/police/cases/<%= caseData.id %>/hearings" method="POST">
   <input type="datetime-local" name="hearingDate">
   <input type="text" name="verdict" placeholder="Verdict">
   <select name="courtId">

--- a/views/partials/hearings-list.ejs
+++ b/views/partials/hearings-list.ejs
@@ -1,7 +1,7 @@
 <h2>Hearings</h2>
-<% if (case.hearings && case.hearings.length > 0) { %>
+<% if (caseData.hearings && caseData.hearings.length > 0) { %>
   <ul>
-    <% case.hearings.forEach(h => { %>
+    <% caseData.hearings.forEach(h => { %>
       <li><%= h.hearingDate.toLocaleString() %> — <%= h.verdict || 'No verdict' %></li>
     <% }) %>
   </ul>

--- a/views/partials/investigations-form.ejs
+++ b/views/partials/investigations-form.ejs
@@ -1,4 +1,4 @@
-<form action="/police/cases/<%= case.id %>/investigations" method="POST">
+<form action="/police/cases/<%= caseData.id %>/investigations" method="POST">
   <input type="text" name="investigatorName" placeholder="Investigator Name">
   <input type="text" name="investigatorBadgeNumber" placeholder="Badge Number">
   <input type="text" name="investigatorRank" placeholder="Rank">

--- a/views/partials/investigations-list.ejs
+++ b/views/partials/investigations-list.ejs
@@ -1,7 +1,7 @@
 <h2>Investigations</h2>
-<% if (case.investigations && case.investigations.length > 0) { %>
+<% if (caseData.investigations && caseData.investigations.length > 0) { %>
   <ul>
-    <% case.investigations.forEach(i => { %>
+    <% caseData.investigations.forEach(i => { %>
       <li><%= i.investigatorName %>: <%= i.details %></li>
     <% }) %>
   </ul>

--- a/views/partials/victim-form.ejs
+++ b/views/partials/victim-form.ejs
@@ -1,4 +1,4 @@
-<form action="/police/cases/<%= case.id %>/victims" method="POST">
+<form action="/police/cases/<%= caseData.id %>/victims" method="POST">
   <input type="text" name="name" placeholder="Victim Name">
   <textarea name="statement" placeholder="Statement"></textarea>
   <button type="submit">Add Victim</button>

--- a/views/partials/victims-list.ejs
+++ b/views/partials/victims-list.ejs
@@ -1,7 +1,7 @@
 <h2>Victims</h2>
-<% if (case.victims && case.victims.length > 0) { %>
+<% if (caseData.victims && caseData.victims.length > 0) { %>
   <ul>
-    <% case.victims.forEach(v => { %>
+    <% caseData.victims.forEach(v => { %>
       <li><%= v.name %> — <%= v.statement || 'No statement' %></li>
     <% }) %>
   </ul>

--- a/views/partials/warrants-form.ejs
+++ b/views/partials/warrants-form.ejs
@@ -1,4 +1,4 @@
-<form action="/police/cases/<%= case.id %>/warrants" method="POST">
+<form action="/police/cases/<%= caseData.id %>/warrants" method="POST">
   <input type="text" name="status" placeholder="Status">
   <textarea name="details" placeholder="Details"></textarea>
   <input type="datetime-local" name="expiresAt">

--- a/views/partials/warrants-list.ejs
+++ b/views/partials/warrants-list.ejs
@@ -1,7 +1,7 @@
 <h2>Warrants</h2>
-<% if (case.warrants && case.warrants.length > 0) { %>
+<% if (caseData.warrants && caseData.warrants.length > 0) { %>
   <ul>
-    <% case.warrants.forEach(w => { %>
+    <% caseData.warrants.forEach(w => { %>
       <li><%= w.status %>: <%= w.details %></li>
     <% }) %>
   </ul>

--- a/views/partials/witness-form.ejs
+++ b/views/partials/witness-form.ejs
@@ -1,4 +1,4 @@
-<form action="/police/cases/<%= case.id %>/witnesses" method="POST">
+<form action="/police/cases/<%= caseData.id %>/witnesses" method="POST">
   <input type="text" name="name" placeholder="Witness Name">
   <textarea name="statement" placeholder="Statement"></textarea>
   <button type="submit">Add Witness</button>

--- a/views/partials/witnesses-list.ejs
+++ b/views/partials/witnesses-list.ejs
@@ -1,7 +1,7 @@
 <h2>Witnesses</h2>
-<% if (case.witnesses && case.witnesses.length > 0) { %>
+<% if (caseData.witnesses && caseData.witnesses.length > 0) { %>
   <ul>
-    <% case.witnesses.forEach(w => { %>
+    <% caseData.witnesses.forEach(w => { %>
       <li><%= w.name %> — <%= w.statement || 'No statement' %></li>
     <% }) %>
   </ul>

--- a/views/police/case-detail.ejs
+++ b/views/police/case-detail.ejs
@@ -31,35 +31,35 @@
         <div class="md:col-span-3">
             <div class="bg-white p-6 rounded-lg shadow-md">
                 <% if (module === 'evidence') { %>
-                    <%- include('../partials/evidence-list', { case: caseData }) %>
+                    <%- include('../partials/evidence-list', { caseData: caseData }) %>
                     <hr class="my-6">
                     <h3 class="text-lg font-bold mb-4">Add Evidence</h3>
-                    <%- include('../partials/evidence-form', { case: caseData }) %>
+                    <%- include('../partials/evidence-form', { caseData: caseData }) %>
                 <% } else if (module === 'investigations') { %>
-                    <%- include('../partials/investigations-list', { case: caseData }) %>
+                    <%- include('../partials/investigations-list', { caseData: caseData }) %>
                     <hr class="my-6">
                     <h3 class="text-lg font-bold mb-4">Add Investigation</h3>
-                    <%- include('../partials/investigations-form', { case: caseData }) %>
+                    <%- include('../partials/investigations-form', { caseData: caseData }) %>
                 <% } else if (module === 'victims') { %>
-                    <%- include('../partials/victims-list', { case: caseData }) %>
+                    <%- include('../partials/victims-list', { caseData: caseData }) %>
                     <hr class="my-6">
                     <h3 class="text-lg font-bold mb-4">Add Victim</h3>
-                    <%- include('../partials/victim-form', { case: caseData }) %>
+                    <%- include('../partials/victim-form', { caseData: caseData }) %>
                 <% } else if (module === 'witnesses') { %>
-                    <%- include('../partials/witnesses-list', { case: caseData }) %>
+                    <%- include('../partials/witnesses-list', { caseData: caseData }) %>
                     <hr class="my-6">
                     <h3 class="text-lg font-bold mb-4">Add Witness</h3>
-                    <%- include('../partials/witness-form', { case: caseData }) %>
+                    <%- include('../partials/witness-form', { caseData: caseData }) %>
                 <% } else if (module === 'hearings') { %>
-                    <%- include('../partials/hearings-list', { case: caseData }) %>
+                    <%- include('../partials/hearings-list', { caseData: caseData }) %>
                     <hr class="my-6">
                     <h3 class="text-lg font-bold mb-4">Add Hearing</h3>
-                    <%- include('../partials/hearing-form', { case: caseData }) %>
+                    <%- include('../partials/hearing-form', { caseData: caseData }) %>
                 <% } else if (module === 'warrants') { %>
-                    <%- include('../partials/warrants-list', { case: caseData }) %>
+                    <%- include('../partials/warrants-list', { caseData: caseData }) %>
                     <hr class="my-6">
                     <h3 class="text-lg font-bold mb-4">Add Warrant</h3>
-                    <%- include('../partials/warrants-form', { case: caseData }) %>
+                    <%- include('../partials/warrants-form', { caseData: caseData }) %>
                 <% } %>
             </div>
         </div>


### PR DESCRIPTION
This commit provides a comprehensive fix for the `SyntaxError: Unexpected token 'case'` that was preventing the case detail page from rendering.

The root cause was the use of the reserved keyword `case` as a variable name within EJS templates. While a previous commit fixed this in the main view, it failed to correct the variable name in the partials that were being included.

This commit addresses the issue by:
1.  Ensuring the `case-detail.ejs` view passes the case object to partials under the key `caseData`.
2.  Systematically updating all relevant partials (`evidence-list`, `evidence-form`, `victims-list`, etc.) to expect and use `caseData` instead of `case`.

This finally resolves the rendering error and should allow the case detail page and its modules to load correctly.