### PR TITLE
fix: Implement robust role assignment in user registration

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -29,12 +29,14 @@ exports.postRegister = async (req, res) => {
 
     const hashedPassword = await bcrypt.hash(password, 10);
 
-    // Default new users to the 'Police' role (roleId: 2 from seed)
+    // Default new users to the 'Police' role
     await prisma.user.create({
       data: {
         username,
         password: hashedPassword,
-        roleId: 2,
+        role: {
+            connect: { name: 'Police' },
+        },
       },
     });
 


### PR DESCRIPTION
This commit fixes a critical `Foreign key constraint violated` error that occurred during user registration. The error was caused by using a hardcoded `roleId` of `2`, which is not guaranteed to be the correct ID for the 'Police' role after database reseeding.

The `postRegister` function in `controllers/authController.js` has been updated to find and connect the 'Police' role by its unique name instead of a hardcoded ID. This makes the registration process robust and resilient to changes in the database.