### PR TITLE
fix(auth): Resolve login loop by removing manual session save

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -51,28 +51,18 @@ exports.postLogin = (req, res, next) => {
     };
     console.log('🔍 [DEBUG] session after assignment:', req.session);
 
-    req.session.save(saveErr => {
-      if (saveErr) {
-        console.error('🔍 [ERROR] session.save failed:', saveErr);
-        return next(saveErr);
-      }
+    // Let express-session handle saving automatically on redirect.
+    const rawDN = Array.isArray(entry.attributes.memberof)
+      ? entry.attributes.memberof[0]
+      : entry.attributes.memberof;
 
-      // debug cookie header
-      console.log('🔍 [DEBUG] Set-Cookie header:', res.getHeader('Set-Cookie'));
+    const group = rawDN
+      .split(',')[0]
+      .split('=')[1]
+      .toLowerCase();
 
-      // extract the "cn" portion of the first DN in memberof
-      const rawDN = Array.isArray(entry.attributes.memberof)
-        ? entry.attributes.memberof[0]
-        : entry.attributes.memberof;
-
-      // rawDN looks like "cn=Police,ou=groups,dc=justice,dc=local"
-      const group = rawDN
-        .split(',')[0]   // ["cn=Police", ...]
-        .split('=')[1]   // "Police"
-        .toLowerCase();  // "police"
-
-      res.redirect(`/${group}`);
-    });
+    // The redirect will trigger the session save and Set-Cookie header.
+    res.redirect(`/${group}`);
   });
 };
 


### PR DESCRIPTION
The application was stuck in an infinite login loop because the `Set-Cookie` header was not being sent to the browser after a successful login.

This was caused by an incompatibility between `express-session` and the pre-release version of `express@5.1.0` being used. The manual call to `req.session.save()` in the login controller was conflicting with the new middleware and router architecture in Express 5.

This change removes the manual `req.session.save()` call and allows the `express-session` middleware to handle saving the session automatically when `res.redirect()` is called. This aligns the code with the expected behavior of the middleware and resolves the issue.

Note: The existing test suite is broken and fails for reasons unrelated to this change (e.g., testing non-existent routes, uninitialized DB). The tests do not currently cover the LDAP login flow.