### PR TITLE
fix: Remove flash messages from views

### DIFF
--- a/views/login.ejs
+++ b/views/login.ejs
@@ -12,21 +12,6 @@
 <body class="bg-gray-100 flex items-center justify-center h-screen">
   <div class="w-full max-w-md">
 
-    <% if (errorMessages.length) { %>
-      <% errorMessages.forEach(msg => { %>
-        <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
-          <strong>Error:</strong> <%= msg %>
-        </div>
-      <% }) %>
-    <% } %>
-
-    <% if (successMessages.length) { %>
-      <% successMessages.forEach(msg => { %>
-        <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded mb-4">
-          <strong>Success:</strong> <%= msg %>
-        </div>
-      <% }) %>
-    <% } %>
 
     <form action="/login" method="POST" class="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">
       <div class="mb-4">


### PR DESCRIPTION
This commit removes the EJS code from `views/login.ejs` that was responsible for displaying flash messages. This code was causing a `ReferenceError` after the `connect-flash` library was removed.

This is the final commit in a series to resolve the session login issue. The root cause was the incompatibility of `connect-flash` with Express 5. The library has been removed, and the views are now cleaned up to reflect this change.