### PR TITLE
fix(auth): Sanitize LDAP data before storing in session

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -44,10 +44,12 @@ exports.postLogin = (req, res, next) => {
     }
 
     // success: stash user
+    // Sanitize the user data by converting it to a plain object with strings.
+    // This prevents session serialization errors from complex LDAP objects.
     req.session.user = {
-      uid:      entry.attributes.uid,
-      cn:       entry.attributes.cn,
-      memberof: entry.attributes.memberof
+      uid:      String(entry.attributes.uid || ''),
+      cn:       String(entry.attributes.cn || ''),
+      memberof: String(entry.attributes.memberof || '')
     };
     console.log('🔍 [DEBUG] session after assignment:', req.session);
 


### PR DESCRIPTION
This commit resolves the persistent session failure by sanitizing the user data returned from the LDAP server before it is stored in the session.

The root cause of the issue was that the `ldapjs` library returns a complex object with its own prototypes, not a plain JavaScript object. When this complex object was assigned to `req.session.user`, it caused the `express-session` serialization process to fail silently, preventing the session from being saved and the `Set-Cookie` header from being sent.

The fix is to explicitly convert the attributes from the LDAP entry to primitive strings before assigning them to `req.session.user`. This ensures that the session data is a simple, serializable POJO (Plain Old JavaScript Object), which prevents the serialization error.