### PR TITLE
feat(debug): Add temporary force-login middleware

### DIFF
--- a/app.js
+++ b/app.js
@@ -56,6 +56,16 @@ try {
   res.send('Session set');
 });
 
+  // Temporary "Force-Login" Middleware for Debugging
+  app.use((req, res, next) => {
+    // To enable, you would set an environment variable, e.g., DEBUG_AUTH=true
+    // For this test, we will force it on.
+    if (true) {
+      req.session.user = { id: 1, name: 'DevOverride', uid: 'dev', cn: 'Dev Override', memberof: 'cn=Police,ou=groups,dc=justice,dc=local' };
+    }
+    next();
+  });
+
 
   // make session available in views
   app.use((req, res, next) => {


### PR DESCRIPTION
This commit adds a temporary middleware to `app.js` for debugging purposes. This middleware unconditionally sets `req.session.user` to a dummy user object on every request.

This is being added to definitively test whether the application's rendering layer is behaving correctly for an authenticated user, thereby isolating the problem to either the rendering layer or the authentication-to-session-persistence pipeline.

This code should be removed after the test is complete.