### PR TITLE
fix(routes): Correct middleware import in cases router

### DIFF
--- a/routes/cases.js
+++ b/routes/cases.js
@@ -2,7 +2,7 @@ const express = require('express');
 const router = express.Router();
 const { PrismaClient } = require('@prisma/client');
 const prisma = new PrismaClient();
-const { checkRole } = require('../middleware/auth');
+const { checkRole } = require('../middleware/authJwt');
 const { createNotification } = require('./notifications');
 
 router.get('/new/:arrestId', checkRole(['Police']), async (req, res) => {


### PR DESCRIPTION
This commit resolves a `MODULE_NOT_FOUND` error that was occurring when the application tried to load the `routes/cases.js` file.

The error was caused by an incorrect `require` statement that was still pointing to the old, deleted `middleware/auth.js` file.

This commit updates the `require` statement to point to the new `middleware/authJwt.js` file, which resolves the error and allows the application to start correctly.